### PR TITLE
Fix AUTO_DETECTION spelling

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     downloader = Downloader(output_path=video_path)
     downloader.download_video()
 
-    AUTO_DECTECTION = False
+    AUTO_DETECTION = False
 
     # # # Process images
     processor = ImageProcessor(
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     )
     processor.select_thumbs()
 
-    if not AUTO_DECTECTION:
+    if not AUTO_DETECTION:
         processor.get_bounds()
         processor.process_files()
     else:


### PR DESCRIPTION
## Summary
- rename `AUTO_DECTECTION` to `AUTO_DETECTION`

## Testing
- `python main.py --no-gui` *(fails: ModuleNotFoundError: No module named 'pytesseract')*


------
https://chatgpt.com/codex/tasks/task_e_68a05e83dfc8832c9a0c6dfb8933595c