### PR TITLE
Handle missing download URL gracefully

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,11 +3,15 @@ import argparse
 import time
 import os
 import configparser
+import logging
+import sys
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--no-gui', action='store_true', help='Run without GUI')
     args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
     
     # Set up directories
     day_info = time.strftime('%Y-%m-%d', time.localtime())[2:]
@@ -21,7 +25,11 @@ if __name__ == "__main__":
   
     # Download video
     downloader = Downloader(output_path=video_path)
-    downloader.download_video()
+    try:
+        downloader.download_video()
+    except ValueError as e:
+        logging.error("Video download skipped: %s", e)
+        sys.exit(1)
 
     AUTO_DETECTION = False
 

--- a/pilar/utils/downloader.py
+++ b/pilar/utils/downloader.py
@@ -5,6 +5,10 @@ import yt_dlp as yt
 import os
 import shutil
 import subprocess
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 class Downloader:
     def __init__(self, output_path):
@@ -12,11 +16,16 @@ class Downloader:
         self.url = None
 
     def download_video(self, url=None):
-        if url is None and self.url is None:
-            self.url = self.get_yn_url()
+        if url is None:
+            if self.url is None:
+                self.url = self.get_yn_url()
             url = self.url
-            
-        now = time.localtime() 
+
+        if url is None:
+            logger.error("No download URL retrieved; skipping download")
+            raise ValueError("No download URL provided or found")
+
+        now = time.localtime()
         now_formatted = time.strftime('%Y%m%d-%H%M%S', now)
         ret = False
 
@@ -25,10 +34,10 @@ class Downloader:
             'merge_output_format': 'mp4',
             'outtmpl': self.output_path
         }
-        
+
         with yt.YoutubeDL(ydl_opts) as ydl:
             ret = ydl.download([url])
-        
+
         return ret, now_formatted
     
     @staticmethod
@@ -53,8 +62,8 @@ class Downloader:
             raise ValueError('No YouTube iframe found on page')
             
         except requests.RequestException as e:
-            print(f'Request failed: {e}')
+            logger.error(f'Request failed: {e}')
             return None
         except Exception as e:
-            print(f'Error: {e}')
+            logger.error(f'Error: {e}')
             return None


### PR DESCRIPTION
## Summary
- add logging and URL check in downloader; raise ValueError when no URL retrieved
- handle download failures gracefully in main.py with error log and exit

## Testing
- `python -m py_compile main.py pilar/utils/downloader.py`


------
https://chatgpt.com/codex/tasks/task_e_68a05f7cea68832c8032b5cadf8cc74e