### PR TITLE
Clarify date format in image uploader

### DIFF
--- a/pilar/utils/image_uploader.py
+++ b/pilar/utils/image_uploader.py
@@ -88,8 +88,8 @@ class ImageUploader:
         login_button.click()
         
     def upload_images(self):
-        # get current YY-MM-DD
-        current_date = datetime.now().strftime("%Y-%m-%d")  
+        # get current YYYY-MM-DD
+        current_date = datetime.now().strftime("%Y-%m-%d")
         # Read config file
         url = self.url
         driver = self.setup_driver()


### PR DESCRIPTION
## Summary
- Correct the date format comment above `current_date` to indicate `YYYY-MM-DD`.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a05ffebef0832cb4398642eba7d092