### PR TITLE
feat: optimize image similarity with OpenCV

### DIFF
--- a/c-porting/main.py
+++ b/c-porting/main.py
@@ -19,9 +19,10 @@ IS_DEDUG=False
 mod_path = 'svm_models.sav'
 svm_clfs = pickle.load(open(mod_path, 'rb'))
 def img_similarity(img1, img2):
-    data1 = img1.flatten()
-    data2 = img2.flatten()
-    return sum(np.isclose(data1, data2, atol=50)) / len(data1)
+    """Return similarity ratio between two binary images using OpenCV."""
+    diff = cv2.absdiff(img1, img2)
+    mask = (diff <= 50).astype(np.uint8)
+    return cv2.countNonZero(mask) / diff.size
 
 
 file_list = [i for i in os.listdir("src/extract/") if not i.startswith('.') and not 'Zone.Identifier' in i]

--- a/pilar/utils/image_processor.py
+++ b/pilar/utils/image_processor.py
@@ -83,9 +83,22 @@ class ImageProcessor:
 
     @staticmethod
     def img_similarity(img1, img2):
-        data1 = img1.flatten()
-        data2 = img2.flatten()
-        return sum(np.isclose(data1, data2, atol=50)) / len(data1)
+        """Return similarity ratio between two binary images.
+
+        The original implementation compared flattened arrays with
+        ``np.isclose`` using an absolute tolerance of ``50``.  This
+        rewrite uses OpenCV operations for better performance:
+
+        1. ``cv2.absdiff`` computes the absolute per-pixel difference.
+        2. ``cv2.countNonZero`` counts pixels whose difference is within
+           the tolerance.
+
+        The result is the fraction of pixels considered similar.
+        """
+
+        diff = cv2.absdiff(img1, img2)
+        mask = (diff <= 50).astype(np.uint8)
+        return cv2.countNonZero(mask) / diff.size
 
     def get_subtilte_bounds(self):
         pass

--- a/tests/test_img_similarity.py
+++ b/tests/test_img_similarity.py
@@ -1,0 +1,17 @@
+import numpy as np
+from pilar.utils.image_processor import ImageProcessor
+
+
+def img_similarity_original(img1, img2):
+    data1 = img1.flatten()
+    data2 = img2.flatten()
+    return np.sum(np.isclose(data1, data2, atol=50)) / len(data1)
+
+
+def test_img_similarity_equivalence():
+    for _ in range(5):
+        img1 = np.random.randint(0, 256, (60, 80), dtype=np.uint8)
+        img2 = np.random.randint(0, 256, (60, 80), dtype=np.uint8)
+        expected = img_similarity_original(img1, img2)
+        actual = ImageProcessor.img_similarity(img1, img2)
+        assert np.isclose(actual, expected)


### PR DESCRIPTION
## Summary
- rewrite `img_similarity` using `cv2.absdiff` and `cv2.countNonZero`
- add tests ensuring new implementation matches previous behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68a063668ec8832c8798b13ed3c34f04