### PR TITLE
feat: switch to rapidfuzz for similarity

### DIFF
--- a/pilar/utils/image_processor.py
+++ b/pilar/utils/image_processor.py
@@ -3,7 +3,7 @@ import cv2
 import os
 import re
 import numpy as np
-from difflib import SequenceMatcher
+from rapidfuzz.distance import Levenshtein
 import matplotlib.pyplot as plt
 from sklearn import svm
 import pickle
@@ -183,7 +183,7 @@ class ImageProcessor:
             if not self.pre_word or cur_word != self.pre_word[0]:
                 str_diff = (
                     max(
-                        SequenceMatcher(None, cur_word, prev_word).ratio()
+                        Levenshtein.normalized_similarity(cur_word, prev_word)
                         for prev_word in self.pre_word
                     )
                     if self.pre_word

--- a/req.txt
+++ b/req.txt
@@ -47,3 +47,4 @@ websocket-client==1.8.0
 websockets==14.1
 wsproto==1.2.0
 yt-dlp==2024.11.23.232923.dev0
+rapidfuzz==3.9.0

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -1,0 +1,42 @@
+import random
+import time
+from difflib import SequenceMatcher
+from rapidfuzz.distance import Levenshtein
+
+
+def seq_ratio(a: str, b: str) -> float:
+    return SequenceMatcher(None, a, b).ratio()
+
+
+def rf_ratio(a: str, b: str) -> float:
+    return Levenshtein.normalized_similarity(a, b)
+
+
+def test_accuracy_and_performance():
+    pairs = [
+        ("hello", "hello"),
+        ("hello", "hallo"),
+        ("apple", "apple"),
+        ("apple", "banana"),
+        ("", ""),
+        ("abcdefgh", "abcxefgh"),
+    ]
+    for a, b in pairs:
+        assert abs(seq_ratio(a, b) - rf_ratio(a, b)) < 0.01
+
+    random.seed(0)
+    sample = [''.join(random.choices('abcdefghijklmnopqrstuvwxyz', k=10)) for _ in range(1000)]
+    pairs = list(zip(sample, reversed(sample)))
+
+    start = time.perf_counter()
+    for a, b in pairs:
+        seq_ratio(a, b)
+    seq_time = time.perf_counter() - start
+
+    start = time.perf_counter()
+    for a, b in pairs:
+        rf_ratio(a, b)
+    rf_time = time.perf_counter() - start
+
+    # Rapidfuzz should be faster than SequenceMatcher
+    assert rf_time < seq_time


### PR DESCRIPTION
## Summary
- use rapidfuzz for string comparisons in ImageProcessor
- add rapidfuzz to Python requirements
- test accuracy and performance of rapidfuzz vs SequenceMatcher

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*

------
https://chatgpt.com/codex/tasks/task_e_68a063712844832caa6d88a977c9dd08